### PR TITLE
feat(runtime): Python runtime via debugpy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export { HandlePool } from "./core/handles.js";
 export type { Runtime, LaunchArguments } from "./core/runtime.js";
 export { EchoRuntime } from "./runtimes/echo.js";
 export { CppLldbRuntime } from "./runtimes/cppLldb.js";
+export { PythonRuntime } from "./runtimes/python.js";

--- a/src/runtimes/python.ts
+++ b/src/runtimes/python.ts
@@ -1,0 +1,273 @@
+import { spawn, type ChildProcess, spawnSync } from "node:child_process";
+import { Buffer } from "node:buffer";
+import type { DebugProtocol } from "@vscode/debugprotocol";
+import type { Runtime, LaunchArguments } from "../core/runtime";
+
+/**
+ * Python runtime — wraps Microsoft's `debugpy` adapter (which already
+ * speaks DAP) as a child process and proxies DAP frames. The wrapper
+ * gives Mythos a place to add value-add features later (custom source
+ * mapping, snapshot capture, distributed debug, …) without forking
+ * debugpy itself.
+ *
+ * Discovery order:
+ *   1. `config.debugAdapter` — explicit adapter command line
+ *   2. `config.python` — Python interpreter to host debugpy
+ *   3. `PYTHON` env var
+ *   4. Platform default (`python3` on POSIX, `py -3` / `python.exe` on
+ *      Windows) resolved through PATH
+ *
+ * If the chosen interpreter cannot import `debugpy`, `start()` rejects
+ * with an actionable error pointing the user at
+ * `python -m pip install debugpy`. We intentionally do NOT pip-install
+ * silently; that should be a Logos-side opt-in setting (tracked in the
+ * Stage 3.5 follow-up plan).
+ */
+
+const HEADER_TERMINATOR = Buffer.from("\r\n\r\n");
+const CONTENT_LENGTH = "content-length:";
+const MAX_BODY = 64 * 1024 * 1024;
+
+type Pending = {
+  resolve(body: unknown): void;
+  reject(err: Error): void;
+  command: string;
+};
+
+export class PythonRuntime implements Runtime {
+  readonly id = "mythos-python";
+  private child: ChildProcess | null = null;
+  private buffer: Buffer = Buffer.alloc(0);
+  private nextSeq = 1;
+  private readonly pending = new Map<number, Pending>();
+  private emit: ((evt: DebugProtocol.Event) => void) | null = null;
+  private readonly config: LaunchArguments;
+
+  constructor(config: LaunchArguments) {
+    this.config = config;
+  }
+
+  async start(emit: (evt: DebugProtocol.Event) => void): Promise<void> {
+    this.emit = emit;
+    const { command, args } = await this.resolveAdapter();
+    this.child = spawn(command, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, ...((this.config.env as Record<string, string>) ?? {}) },
+      cwd: this.config.cwd,
+    });
+    this.child.stdout?.on("data", (chunk: Buffer) => this.feed(chunk));
+    this.child.stderr?.on("data", (chunk: Buffer) => {
+      this.emit?.({
+        seq: 0,
+        type: "event",
+        event: "output",
+        body: { category: "stderr", output: chunk.toString("utf8") },
+      } as DebugProtocol.OutputEvent);
+    });
+    this.child.once("exit", (code) => {
+      for (const [, slot] of this.pending.entries()) {
+        slot.reject(new Error(`debugpy exited with code ${code ?? "unknown"} while '${slot.command}' was pending`));
+      }
+      this.pending.clear();
+      if (this.emit) {
+        this.emit({
+          seq: 0,
+          type: "event",
+          event: "output",
+          body: { category: "console", output: `debugpy exited (code=${code ?? "?"})\n` },
+        } as DebugProtocol.OutputEvent);
+        this.emit({
+          seq: 0,
+          type: "event",
+          event: "terminated",
+        } as DebugProtocol.TerminatedEvent);
+      }
+      this.child = null;
+    });
+    this.child.once("error", (err) => {
+      this.emit?.({
+        seq: 0,
+        type: "event",
+        event: "output",
+        body: { category: "stderr", output: `debugpy error: ${err.message}\n` },
+      } as DebugProtocol.OutputEvent);
+    });
+
+    await this.request("initialize", {
+      clientID: "mythosdbg",
+      adapterID: "mythos-python",
+      pathFormat: "path",
+      linesStartAt1: true,
+      columnsStartAt1: true,
+    });
+    await this.request(this.config.request === "attach" ? "attach" : "launch", this.config);
+  }
+
+  async handle(command: string, args: unknown): Promise<unknown> {
+    return this.request(command, args);
+  }
+
+  async dispose(): Promise<void> {
+    if (!this.child) return;
+    try {
+      await this.request("disconnect", { terminateDebuggee: this.config.request !== "attach" });
+    } catch {
+      /* ignore — adapter may already have torn down */
+    }
+    if (this.child && this.child.exitCode === null) {
+      try {
+        this.child.kill();
+      } catch {
+        /* ignore */
+      }
+    }
+    this.child = null;
+    this.emit = null;
+  }
+
+  private async resolveAdapter(): Promise<{ command: string; args: string[] }> {
+    const explicit = this.config.debugAdapter as string | undefined;
+    if (explicit && explicit.length > 0) {
+      // Treat the explicit value as a single executable; users with
+      // arguments embed them via `debugAdapterArgs`.
+      const extra = (this.config.debugAdapterArgs as string[] | undefined) ?? [];
+      return { command: explicit, args: extra };
+    }
+    const interpreter = this.resolvePython();
+    this.assertDebugpyImportable(interpreter);
+    return { command: interpreter, args: ["-m", "debugpy.adapter"] };
+  }
+
+  private resolvePython(): string {
+    const explicit = this.config.python as string | undefined;
+    if (explicit && explicit.length > 0) return explicit;
+    const fromEnv = process.env.PYTHON;
+    if (fromEnv && fromEnv.length > 0) return fromEnv;
+    if (process.platform === "win32") {
+      // Prefer the launcher when available; PowerShell users typically
+      // alias `python` to `py -3`.
+      const py = spawnSync("where", ["py"], { encoding: "utf8" });
+      if (py.status === 0 && py.stdout.trim()) return "py";
+      const pyexe = spawnSync("where", ["python"], { encoding: "utf8" });
+      if (pyexe.status === 0 && pyexe.stdout.trim()) {
+        return pyexe.stdout.split(/\r?\n/)[0].trim();
+      }
+      return "python";
+    }
+    const which3 = spawnSync("/usr/bin/env", ["which", "python3"], {
+      encoding: "utf8",
+    });
+    if (which3.status === 0 && which3.stdout.trim()) return which3.stdout.trim();
+    const which = spawnSync("/usr/bin/env", ["which", "python"], {
+      encoding: "utf8",
+    });
+    if (which.status === 0 && which.stdout.trim()) return which.stdout.trim();
+    throw new Error(
+      "Could not locate a Python interpreter. Install Python 3.8+ and ensure it is on PATH, or set `python` in launch.json.",
+    );
+  }
+
+  private assertDebugpyImportable(interpreter: string): void {
+    const probe = spawnSync(
+      interpreter,
+      // The launcher (`py`) needs `-3` to disambiguate; bare interpreters ignore it.
+      interpreter.endsWith("py") || interpreter === "py"
+        ? ["-3", "-c", "import debugpy"]
+        : ["-c", "import debugpy"],
+      { encoding: "utf8" },
+    );
+    if (probe.status !== 0) {
+      const hint = `${interpreter} -m pip install debugpy`;
+      throw new Error(
+        `Python interpreter '${interpreter}' cannot import debugpy. Install it with: ${hint}`,
+      );
+    }
+  }
+
+  private feed(chunk: Buffer): void {
+    this.buffer = this.buffer.length === 0
+      ? chunk
+      : Buffer.concat([this.buffer, chunk]);
+    while (true) {
+      const headerEnd = this.buffer.indexOf(HEADER_TERMINATOR);
+      if (headerEnd < 0) return;
+      const headerText = this.buffer.subarray(0, headerEnd).toString("ascii");
+      let bodyLen = -1;
+      for (const line of headerText.split("\r\n")) {
+        if (line.toLowerCase().startsWith(CONTENT_LENGTH)) {
+          const num = Number(line.slice(CONTENT_LENGTH.length).trim());
+          if (Number.isFinite(num) && num >= 0) bodyLen = num;
+        }
+      }
+      if (bodyLen < 0 || bodyLen > MAX_BODY) {
+        this.buffer = Buffer.alloc(0);
+        return;
+      }
+      const total = headerEnd + HEADER_TERMINATOR.length + bodyLen;
+      if (this.buffer.length < total) return;
+      const body = this.buffer.subarray(headerEnd + HEADER_TERMINATOR.length, total);
+      this.buffer = this.buffer.subarray(total);
+      try {
+        const msg = JSON.parse(body.toString("utf8")) as DebugProtocol.ProtocolMessage;
+        this.dispatchInbound(msg);
+      } catch {
+        /* drop malformed frame; do not desync */
+      }
+    }
+  }
+
+  private dispatchInbound(msg: DebugProtocol.ProtocolMessage): void {
+    if (msg.type === "response") {
+      const r = msg as DebugProtocol.Response;
+      const slot = this.pending.get(r.request_seq);
+      if (!slot) return;
+      this.pending.delete(r.request_seq);
+      if (r.success) slot.resolve(r.body);
+      else slot.reject(new Error(r.message ?? `debugpy '${slot.command}' failed`));
+      return;
+    }
+    if (msg.type === "event") {
+      this.emit?.(msg as DebugProtocol.Event);
+      return;
+    }
+    if (msg.type === "request") {
+      const req = msg as DebugProtocol.Request;
+      const reply: DebugProtocol.Response = {
+        seq: this.nextSeq++,
+        type: "response",
+        request_seq: req.seq,
+        success: false,
+        command: req.command,
+        message: "Mythos does not currently forward reverse requests",
+      };
+      this.write(reply);
+    }
+  }
+
+  private request(command: string, args: unknown): Promise<unknown> {
+    if (!this.child) return Promise.reject(new Error("debugpy is not running"));
+    const seq = this.nextSeq++;
+    const req: DebugProtocol.Request = {
+      seq,
+      type: "request",
+      command,
+      arguments: args,
+    };
+    return new Promise<unknown>((resolve, reject) => {
+      this.pending.set(seq, { resolve, reject, command });
+      try {
+        this.write(req);
+      } catch (err) {
+        this.pending.delete(seq);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  private write(msg: DebugProtocol.ProtocolMessage): void {
+    const body = JSON.stringify(msg);
+    const head = `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n`;
+    this.child?.stdin?.write(head);
+    this.child?.stdin?.write(body, "utf8");
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,14 +1,16 @@
 import { MythosSession } from "./core/mythosSession.js";
 import { EchoRuntime } from "./runtimes/echo.js";
 import { CppLldbRuntime } from "./runtimes/cppLldb.js";
+import { PythonRuntime } from "./runtimes/python.js";
 import type { LaunchArguments, Runtime } from "./core/runtime.js";
 
 /**
  * Mythos DAP server entry point. Picks the runtime by the launch
  * config's `type` field and hands off to MythosSession.
  *
- *   - `mythos-echo` → EchoRuntime (built-in self-test)
- *   - `mythos-cpp`  → CppLldbRuntime (lldb-dap wrapper, prototype)
+ *   - `mythos-echo`   → EchoRuntime (built-in self-test)
+ *   - `mythos-cpp`    → CppLldbRuntime (lldb-dap wrapper, prototype)
+ *   - `mythos-python` → PythonRuntime (debugpy wrapper)
  *
  * Anything else throws on `launch`. New runtime types are added in
  * `runtimes/` and registered in `runtimeFactory` here.
@@ -19,6 +21,8 @@ function runtimeFactory(config: LaunchArguments): Runtime {
       return new EchoRuntime(config);
     case "mythos-cpp":
       return new CppLldbRuntime(config);
+    case "mythos-python":
+      return new PythonRuntime(config);
     default:
       throw new Error(`mythosdbg: unsupported launch type '${config.type}'`);
   }

--- a/tests/python.test.ts
+++ b/tests/python.test.ts
@@ -1,0 +1,48 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { PythonRuntime } from "../src/runtimes/python";
+
+/**
+ * PythonRuntime is a thin wrapper over `python -m debugpy.adapter`. The
+ * test detects whether a Python interpreter with debugpy is available;
+ * if not, the end-to-end placeholder is skipped (matches the
+ * cppLldb.test.ts pattern).
+ *
+ * The synchronous interpreter-resolution and importability checks are
+ * exercised unconditionally — they are the parts users hit first when
+ * something is misconfigured.
+ */
+function pythonWithDebugpy(): string | null {
+  for (const candidate of ["python3", "python"]) {
+    const which = spawnSync("/usr/bin/env", ["which", candidate], {
+      encoding: "utf8",
+    });
+    if (which.status !== 0 || !which.stdout.trim()) continue;
+    const probe = spawnSync(which.stdout.trim(), ["-c", "import debugpy"], {
+      encoding: "utf8",
+    });
+    if (probe.status === 0) return which.stdout.trim();
+  }
+  return null;
+}
+
+describe("PythonRuntime", () => {
+  it("rejects start when no python is on PATH and config.python is missing", async () => {
+    const r = new PythonRuntime({
+      type: "mythos-python",
+      request: "launch",
+      name: "test",
+      python: "/definitely/not/a/path/to/python",
+    });
+    await expect(r.start(() => undefined)).rejects.toThrow(/cannot import debugpy|ENOENT|spawn/);
+  });
+
+  it.skipIf(!pythonWithDebugpy())(
+    "spawns debugpy and forwards a launch request (placeholder; expanded with full E2E)",
+    () => {
+      // Real Python end-to-end (run a tiny .py, hit a breakpoint) is
+      // not wired up yet; we keep the slot warm for CI on hosts that
+      // ship debugpy. Tracked alongside the cppLldb harness story.
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Adds the `mythos-python` runtime that wraps `python -m debugpy.adapter` and proxies DAP frames, mirroring the `cppLldb` skeleton.
- Discovers a Python interpreter via `config.python` → `\$PYTHON` → platform default (POSIX `python3`/`python`, Windows `py -3` / `python.exe`).
- Verifies `debugpy` is importable before spawning, emitting an actionable `pip install debugpy` hint when it is not.
- Honors `request: \"attach\"` end-to-end: forwards to the upstream `attach` request and defaults `terminateDebuggee` to false on disconnect so attaching does not kill the debuggee.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — all suites green (3 passed, 1 skipped on hosts without debugpy)
- [ ] Manual: `launch.json` with `type: \"mythos-python\", program: \"main.py\"` runs and stops on a breakpoint
- [ ] Manual: attach against `python -m debugpy --listen 5678 --wait-for-client app.py`

Closes #5.