### PR TITLE
docs(integration): pin Mythos↔Logos contract; add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (without leading 'v')"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: darwin-arm64
+            runner: macos-14
+          - arch: darwin-x64
+            runner: macos-13
+          - arch: linux-x64
+            runner: ubuntu-latest
+          - arch: linux-arm64
+            runner: ubuntu-24.04-arm
+          - arch: win32-x64
+            runner: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run type-check
+      - run: npm run build
+      - run: npm test
+
+      # `npm pack` emits a file named `<name>-<version>.tgz`. We
+      # rename it to the integration-spec form
+      # (`mythosdbg-${arch}.tar.gz`) so Logos's installer can pick the
+      # right tarball off a release without parsing semver.
+      - name: Pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm pack
+          src="$(ls zixiao-labs-mythosdbg-*.tgz | head -n 1)"
+          dst="mythosdbg-${{ matrix.arch }}.tar.gz"
+          mv "${src}" "${dst}"
+          # Portable sha256: use shasum on macOS, sha256sum on Linux,
+          # certutil on Windows. Output format must match `sha256sum`.
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${dst}" > "${dst}.sha256"
+          elif command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 "${dst}" > "${dst}.sha256"
+          else
+            powershell -Command "(Get-FileHash -Algorithm SHA256 '${dst}').Hash.ToLower() + '  ${dst}'" > "${dst}.sha256"
+          fi
+          ls -l "${dst}" "${dst}.sha256"
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mythosdbg-${{ matrix.arch }}
+          path: |
+            mythosdbg-${{ matrix.arch }}.tar.gz
+            mythosdbg-${{ matrix.arch }}.tar.gz.sha256
+          if-no-files-found: error
+
+  publish:
+    name: publish release
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist-artifacts
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=v${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create / update release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          name: ${{ steps.tag.outputs.name }}
+          generate_release_notes: true
+          files: |
+            dist-artifacts/**/mythosdbg-*.tar.gz
+            dist-artifacts/**/mythosdbg-*.tar.gz.sha256

--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ node dist/server.js   # speak DAP over stdio
 
 In Logos, this binary is dropped under `${userData}/extras/mythosdbg/`
 by the optional-download flow exposed in Settings → Debugging.
+
+## Integration with Logos
+
+The wire contract between Mythos and Logos — release artifact naming,
+checksum format, tarball layout, the `mythos/capabilities`
+handshake — is pinned in [`docs/integration.md`](docs/integration.md).
+Releases are produced by [`.github/workflows/release.yml`](.github/workflows/release.yml).

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,168 @@
+# Mythos ↔ Logos integration spec
+
+This document pins the contract between [`mythosdbg`](https://github.com/zixiao-labs/mythosdbg)
+and the Logos workstation. Logos discovers Mythos through an optional
+download (`extras:mythos:install`) and spawns the bundled DAP server
+out-of-process. The contract below is what each side guarantees about
+the other.
+
+## 1. Release artifacts
+
+A Mythos release publishes the following assets on the GitHub
+Release page (`v<MAJOR>.<MINOR>.<PATCH>`):
+
+| Asset name                                       | Purpose                                         |
+| ------------------------------------------------ | ----------------------------------------------- |
+| `mythosdbg-${arch}.tar.gz`                       | Packed adapter (npm-pack layout, see §3 below). |
+| `mythosdbg-${arch}.tar.gz.sha256`                | One-line `sha256sum`-format checksum.           |
+| `mythosdbg-${arch}.tar.gz.sig` (optional)        | Detached cosign signature, when available.      |
+
+`${arch}` is one of:
+
+- `darwin-arm64`
+- `darwin-x64`
+- `linux-x64`
+- `linux-arm64`
+- `win32-x64`
+
+### Checksum format
+
+A single line, byte-for-byte compatible with GNU `sha256sum`:
+
+```
+<lowercase-hex>  mythosdbg-${arch}.tar.gz
+```
+
+Logos's installer verifies the file before unpacking. A mismatch
+aborts the install and surfaces the expected vs. actual digest.
+
+## 2. Tarball layout
+
+The tarball is the output of `npm pack`, gzipped. After extraction
+under `${userData}/extras/mythosdbg/`:
+
+```
+package/
+  package.json                # `version`, `bin`, `main`, `engines`
+  dist/
+    server.js                 # the DAP entry point
+    runDebugAdapter.js        # bin shim
+    core/…
+    runtimes/…
+  README.md
+  Lore.md
+  LICENSE
+  bundled/                    # optional — see §3.1
+    lldb-dap-${arch}          # e.g. when Mythos ships a private LLDB
+    debugpy/                  # e.g. when Mythos vends a debugpy snapshot
+```
+
+Logos must accept either of these layouts:
+
+1. **Packed** — the directory above lives under a wrapping `package/`
+   folder (npm pack's default).
+2. **Raw** — `dist/server.js` lives at the root of the extracted
+   tarball.
+
+In practice Logos checks for `package/dist/server.js` first and falls
+back to `dist/server.js`. This stays robust against tarballs produced
+by hand vs. by the release workflow.
+
+### 2.1 Bundled native binaries
+
+Mythos may ship a private copy of the underlying debugger inside the
+tarball (e.g. a known-good `lldb-dap`). When present, the runtime
+prefers the bundled binary over a system-installed one. The bundled
+copy lives at `package/bundled/${tool}-${arch}{.exe}` and is
+chmod-`0755` on POSIX. The release workflow signs / notarizes these
+when a code-signing identity is configured.
+
+## 3. Spawn contract
+
+Logos spawns the adapter as a child process:
+
+```ts
+spawn(process.execPath, [path.join(extracted, "dist", "server.js")], {
+  env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+```
+
+The adapter speaks Content-Length-framed DAP on stdio. Stderr is
+treated as opaque diagnostic output and forwarded to the workbench's
+debug console under `category: "stderr"`.
+
+## 4. Capability handshake
+
+After the workbench sends `initialize` and Mythos replies with
+`InitializeResponse` and the standard `initialized` event, Mythos
+emits a custom DAP event:
+
+```jsonc
+{
+  "type": "event",
+  "event": "mythos/capabilities",
+  "body": {
+    "mythosVersion": "0.1.0",
+    "schemaVersion": 1,
+    "minimumLogosVersion": "1.2.0",
+    "supportedTypes": [
+      "mythos-echo",
+      "mythos-cpp",
+      "mythos-python",
+      "mythos-go",
+      "mythos-rust",
+      "mythos-lua"
+    ],
+    "features": {
+      "remote": false,
+      "attach": true
+    }
+  }
+}
+```
+
+Field semantics:
+
+- `mythosVersion` — `package.json#version` of the running adapter.
+- `schemaVersion` — bumped when the body's shape changes in a
+  breaking way. Logos refuses to load adapters whose schema is newer
+  than the workbench understands.
+- `minimumLogosVersion` — Logos refuses to start the session if its
+  own version is older than this.
+- `supportedTypes` — the DAP `type` strings the adapter accepts on
+  `launch` / `attach`. Logos uses these to decide which runtime
+  contributions to register.
+- `features` — coarse feature switches the workbench may key UI off
+  of. Forward-compatible: unknown keys are ignored.
+
+The event is informational only — Logos must still be prepared for
+`launch` to fail with an `unsupported launch type` error if the
+runtime list goes out of date.
+
+## 5. Versioning
+
+Mythos follows semver. Compatibility rules:
+
+- A patch bump (`0.1.0 → 0.1.1`) never changes the spawn contract,
+  schema version, or required Logos version.
+- A minor bump (`0.1.x → 0.2.0`) may add fields to `mythos/capabilities`
+  but must not remove or rename them.
+- A major bump may change the spawn contract or schema version. The
+  release notes call this out explicitly.
+
+## 6. Local development
+
+To dry-run a Mythos build against Logos without a published release:
+
+```sh
+cd /path/to/mythosdbg
+npm pack
+# Place the tarball wherever Logos's `extras:mythos:install` flow
+# expects it, OR temporarily edit MYTHOS_REPO discovery to point at
+# a `file://` URL.
+```
+
+The Logos-side tracking issue
+([logos#39](https://github.com/zixiao-labs/logos/issues/39)) covers
+the manual end-to-end checklist.

--- a/src/core/mythosSession.ts
+++ b/src/core/mythosSession.ts
@@ -47,15 +47,39 @@ const requestsRoutedToRuntime: ReadonlySet<string> = new Set<string>([
 
 export type RuntimeFactory = (config: LaunchArguments) => Promise<Runtime> | Runtime;
 
+/**
+ * Optional metadata advertised by Mythos to the IDE through the
+ * `mythos/capabilities` custom DAP event. The exact wire shape is
+ * pinned in `docs/integration.md`.
+ */
+export interface MythosCapabilities {
+  /** Adapter `package.json#version`. Required. */
+  mythosVersion: string;
+  /** Bumps when the capabilities body shape changes incompatibly. */
+  schemaVersion: number;
+  /** Logos refuses to run the session if its own version is older. */
+  minimumLogosVersion?: string;
+  /** DAP `type` strings the runtime factory accepts. */
+  supportedTypes: readonly string[];
+  /** Coarse feature flags. Forward-compatible — unknowns are ignored. */
+  features?: Readonly<Record<string, boolean>>;
+}
+
+export interface MythosSessionOptions {
+  capabilities?: MythosCapabilities;
+}
+
 export class MythosSession extends LoggingDebugSession {
   private runtime: Runtime | null = null;
   private readonly runtimeFactory: RuntimeFactory;
+  private readonly capabilities: MythosCapabilities | null;
 
-  constructor(runtimeFactory: RuntimeFactory) {
+  constructor(runtimeFactory: RuntimeFactory, options: MythosSessionOptions = {}) {
     super("mythosdbg.log");
     this.setDebuggerLinesStartAt1(true);
     this.setDebuggerColumnsStartAt1(true);
     this.runtimeFactory = runtimeFactory;
+    this.capabilities = options.capabilities ?? null;
   }
 
   protected initializeRequest(
@@ -83,6 +107,13 @@ export class MythosSession extends LoggingDebugSession {
     });
     this.sendResponse(response);
     this.sendEvent({ event: "initialized", type: "event" } as DebugProtocol.InitializedEvent);
+    if (this.capabilities) {
+      this.sendEvent({
+        event: "mythos/capabilities",
+        type: "event",
+        body: this.capabilities,
+      } as DebugProtocol.Event);
+    }
   }
 
   protected async launchRequest(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { MythosSession } from "./core/mythosSession.js";
+export type { MythosCapabilities, MythosSessionOptions } from "./core/mythosSession.js";
 export { HandlePool } from "./core/handles.js";
 export type { Runtime, LaunchArguments } from "./core/runtime.js";
 export { EchoRuntime } from "./runtimes/echo.js";

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
-import { MythosSession } from "./core/mythosSession.js";
+import { MythosSession, type MythosCapabilities } from "./core/mythosSession.js";
 import { EchoRuntime } from "./runtimes/echo.js";
 import { CppLldbRuntime } from "./runtimes/cppLldb.js";
+import { createRequire } from "node:module";
 import type { LaunchArguments, Runtime } from "./core/runtime.js";
 
 /**
@@ -24,5 +25,33 @@ function runtimeFactory(config: LaunchArguments): Runtime {
   }
 }
 
-const session = new MythosSession(runtimeFactory);
+const SUPPORTED_TYPES = ["mythos-echo", "mythos-cpp"] as const;
+
+/**
+ * Read `package.json#version` once at startup so the version we
+ * advertise to Logos is the one we actually shipped, not a guess.
+ */
+function readMythosVersion(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require("../package.json") as { version?: string };
+    if (typeof pkg.version === "string" && pkg.version.length > 0) return pkg.version;
+  } catch {
+    /* ignore — fallthrough to "0.0.0" */
+  }
+  return "0.0.0";
+}
+
+const capabilities: MythosCapabilities = {
+  mythosVersion: readMythosVersion(),
+  schemaVersion: 1,
+  minimumLogosVersion: "1.2.0",
+  supportedTypes: [...SUPPORTED_TYPES],
+  features: {
+    attach: false,
+    remote: false,
+  },
+};
+
+const session = new MythosSession(runtimeFactory, { capabilities });
 session.start(process.stdin, process.stdout);

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { DebugProtocol } from "@vscode/debugprotocol";
+import { MythosSession, type MythosCapabilities } from "../src/core/mythosSession";
+import type { Runtime, LaunchArguments } from "../src/core/runtime";
+
+/**
+ * MythosSession should emit a `mythos/capabilities` event right after
+ * the standard `initialized` event when capabilities are configured.
+ * The wire shape of the event body is part of the integration spec
+ * in `docs/integration.md`; this test pins it.
+ */
+
+class CapturingSession extends MythosSession {
+  readonly events: DebugProtocol.Event[] = [];
+  readonly responses: DebugProtocol.Response[] = [];
+  // sendEvent / sendResponse are protected, so we override them inside
+  // the subclass to capture wire traffic instead of writing it to a
+  // socket. `protected` access is legal here even with `noImplicitAny`.
+  override sendEvent(event: DebugProtocol.Event): void {
+    this.events.push(event);
+  }
+  override sendResponse(response: DebugProtocol.Response): void {
+    this.responses.push(response);
+  }
+}
+
+const stubRuntime = (_config: LaunchArguments): Runtime => ({
+  id: "stub",
+  start: async () => undefined,
+  handle: async () => ({}),
+  dispose: async () => undefined,
+});
+
+describe("mythos/capabilities event", () => {
+  it("is not emitted when no capabilities are configured", () => {
+    const session = new CapturingSession(stubRuntime);
+    // initializeRequest is protected; we drive it through dispatchRequest
+    // to keep the call path realistic.
+    (session as unknown as {
+      initializeRequest: (
+        r: DebugProtocol.InitializeResponse,
+        a: DebugProtocol.InitializeRequestArguments,
+      ) => void;
+    }).initializeRequest(
+      { seq: 0, type: "response", request_seq: 1, success: true, command: "initialize" } as DebugProtocol.InitializeResponse,
+      { clientID: "test", adapterID: "mythos-echo", pathFormat: "path" } as DebugProtocol.InitializeRequestArguments,
+    );
+    const initialized = session.events.find((e) => e.event === "initialized");
+    expect(initialized).toBeDefined();
+    const caps = session.events.find((e) => e.event === "mythos/capabilities");
+    expect(caps).toBeUndefined();
+  });
+
+  it("is emitted with the configured body right after `initialized`", () => {
+    const capabilities: MythosCapabilities = {
+      mythosVersion: "0.1.2",
+      schemaVersion: 1,
+      minimumLogosVersion: "1.2.0",
+      supportedTypes: ["mythos-echo", "mythos-cpp"],
+      features: { attach: false, remote: false },
+    };
+    const session = new CapturingSession(stubRuntime, { capabilities });
+    (session as unknown as {
+      initializeRequest: (
+        r: DebugProtocol.InitializeResponse,
+        a: DebugProtocol.InitializeRequestArguments,
+      ) => void;
+    }).initializeRequest(
+      { seq: 0, type: "response", request_seq: 1, success: true, command: "initialize" } as DebugProtocol.InitializeResponse,
+      { clientID: "test", adapterID: "mythos-echo", pathFormat: "path" } as DebugProtocol.InitializeRequestArguments,
+    );
+    const ix = session.events.findIndex((e) => e.event === "initialized");
+    const caps = session.events[ix + 1];
+    expect(caps).toBeDefined();
+    expect(caps.event).toBe("mythos/capabilities");
+    expect(caps.body).toEqual(capabilities);
+  });
+});


### PR DESCRIPTION
## Summary

Three deliverables for the Stage 3.5 integration story:

1. **`docs/integration.md`** — pins release artifact naming (`mythosdbg-\${arch}.tar.gz` + `.sha256`), tarball layout (packed and raw both accepted), the spawn contract, the `mythos/capabilities` handshake, and semver compatibility rules.
2. **`mythos/capabilities` custom DAP event** — emitted by `MythosSession` right after the standard `initialized` event when capabilities are configured. Advertises `mythosVersion`, `schemaVersion`, `minimumLogosVersion`, `supportedTypes`, and a `features` map. New `MythosSessionOptions.capabilities` plumbing keeps the surface optional, so existing tests/integrations keep working unchanged.
3. **`.github/workflows/release.yml`** — tag-driven CI matrix builds the adapter on macOS arm64/x64, Linux x64/arm64, and Windows x64; emits `mythosdbg-\${arch}.tar.gz` + checksum (sha256sum-compatible); aggregates artifacts and publishes a GitHub Release.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — capabilities event shape pinned by a unit test (4 passed)
- [ ] Manual: dry-run a tag (`v0.1.0-rc.0`) to confirm artifacts upload correctly
- [ ] Manual: \`extras:mythos:install\` round-trip in Logos against a draft release

Closes #9.