### PR TITLE
feat(attach): JIT-attach by PID/name with ptrace hints

### DIFF
--- a/src/core/processes.ts
+++ b/src/core/processes.ts
@@ -1,0 +1,248 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+/**
+ * Process discovery for the `attach` flow. We deliberately keep this
+ * dependency-free: `ps` on POSIX, `tasklist` on Windows. Each backend
+ * returns the same `ProcessInfo` shape so the rest of the codebase
+ * does not need platform branches.
+ *
+ * Mythos uses this in two places:
+ *   1. The Logos UI surfaces a process picker when a user starts an
+ *      attach session without `processId` set.
+ *   2. Each runtime calls `findProcesses({ name })` to convert a
+ *      user-supplied executable basename into a concrete PID before
+ *      forwarding `attach` to the underlying debugger.
+ */
+
+export interface ProcessInfo {
+  pid: number;
+  /** Executable basename (no path, no args). */
+  name: string;
+  /** Full command line as the OS reports it. May be truncated on Windows. */
+  command: string;
+  /** Owning user, when available. */
+  user?: string;
+}
+
+export interface FindProcessesQuery {
+  /** Exact PID. When set, the helper still verifies the process exists. */
+  pid?: number;
+  /**
+   * Executable basename or substring (case-insensitive) match against
+   * `command`. When more than one process matches, the caller decides
+   * how to disambiguate.
+   */
+  name?: string;
+}
+
+/**
+ * Snapshot the running process list and return matches.
+ *
+ * Throws when the platform helper (`ps` / `tasklist`) is unavailable,
+ * so callers can surface that as an actionable error in the UI.
+ */
+export function findProcesses(query: FindProcessesQuery = {}): ProcessInfo[] {
+  const all = listProcesses();
+  return all.filter((p) => matchesQuery(p, query));
+}
+
+export function listProcesses(): ProcessInfo[] {
+  if (process.platform === "win32") return listProcessesWindows();
+  return listProcessesPosix();
+}
+
+function matchesQuery(info: ProcessInfo, query: FindProcessesQuery): boolean {
+  if (query.pid !== undefined && info.pid !== query.pid) return false;
+  if (query.name !== undefined) {
+    const needle = query.name.toLowerCase();
+    if (
+      !info.name.toLowerCase().includes(needle) &&
+      !info.command.toLowerCase().includes(needle)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function listProcessesPosix(): ProcessInfo[] {
+  // `ps -eo pid=,user=,comm=,args=` is portable across macOS and Linux
+  // (BSD `ps` and procps both accept it) and avoids locale-dependent
+  // header parsing.
+  const r = spawnSync("ps", ["-eo", "pid=,user=,comm=,args="], {
+    encoding: "utf8",
+  });
+  if (r.status !== 0) {
+    throw new Error(`ps failed (exit ${r.status}): ${r.stderr.trim()}`);
+  }
+  return parsePosixPs(r.stdout);
+}
+
+/** Exported for unit tests — see tests/processes.test.ts. */
+export function parsePosixPs(stdout: string): ProcessInfo[] {
+  const out: ProcessInfo[] = [];
+  for (const raw of stdout.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    // PID USER COMM ARGS — COMM has no spaces, ARGS may have many.
+    const m = /^(\d+)\s+(\S+)\s+(\S+)\s+(.*)$/.exec(line);
+    if (!m) continue;
+    const pid = Number(m[1]);
+    if (!Number.isFinite(pid)) continue;
+    out.push({
+      pid,
+      user: m[2],
+      name: basenameOf(m[3]),
+      command: m[4],
+    });
+  }
+  return out;
+}
+
+function listProcessesWindows(): ProcessInfo[] {
+  // /FO CSV gives us a stable, parseable format. /NH suppresses the
+  // header row so we can split lines uniformly.
+  const r = spawnSync("tasklist", ["/FO", "CSV", "/NH"], {
+    encoding: "utf8",
+  });
+  if (r.status !== 0) {
+    throw new Error(`tasklist failed (exit ${r.status}): ${r.stderr.trim()}`);
+  }
+  return parseWindowsTasklist(r.stdout);
+}
+
+/** Exported for unit tests. */
+export function parseWindowsTasklist(stdout: string): ProcessInfo[] {
+  const out: ProcessInfo[] = [];
+  for (const raw of stdout.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    // `tasklist /FO CSV /NH` columns:
+    //   "Image Name","PID","Session Name","Session#","Mem Usage"
+    const cells = parseCsvLine(line);
+    if (cells.length < 2) continue;
+    const pid = Number(cells[1]);
+    if (!Number.isFinite(pid)) continue;
+    out.push({
+      pid,
+      name: cells[0],
+      command: cells[0],
+    });
+  }
+  return out;
+}
+
+function parseCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let inQuote = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuote && line[i + 1] === '"') {
+        cur += '"';
+        i++;
+      } else {
+        inQuote = !inQuote;
+      }
+      continue;
+    }
+    if (ch === "," && !inQuote) {
+      out.push(cur);
+      cur = "";
+      continue;
+    }
+    cur += ch;
+  }
+  out.push(cur);
+  return out;
+}
+
+function basenameOf(p: string): string {
+  const i = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  return i >= 0 ? p.slice(i + 1) : p;
+}
+
+/**
+ * On Linux, `ptrace(PTRACE_ATTACH, …)` is restricted by default.
+ * Returns a hint string when the host is configured in a way that
+ * will cause attach to fail with `EPERM`, or `null` when permissions
+ * look fine. Mythos surfaces the hint in the launch error so users do
+ * not need to grep kernel docs.
+ */
+export function checkPtraceScopeHint(): string | null {
+  if (process.platform !== "linux") return null;
+  try {
+    const v = readFileSync("/proc/sys/kernel/yama/ptrace_scope", "utf8").trim();
+    if (v === "0") return null;
+    return [
+      `Linux yama ptrace_scope is set to ${v}.`,
+      "Attach may require sudo or `echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope`",
+      "(see https://docs.kernel.org/admin-guide/LSM/Yama.html).",
+    ].join(" ");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a user-supplied attach configuration to a concrete PID.
+ *
+ * Accepts either:
+ *   - `processId` — a number; returned as-is after a liveness check
+ *   - `processName` — a basename / substring; matched against the
+ *     running process list. If more than one match is found, the
+ *     caller is expected to surface a picker — we throw with the
+ *     candidate list so the IDE can render it.
+ */
+export interface AttachSelector {
+  processId?: number;
+  processName?: string;
+}
+
+export function resolveAttachPid(selector: AttachSelector): number {
+  if (selector.processId !== undefined) {
+    if (!Number.isFinite(selector.processId) || selector.processId <= 0) {
+      throw new Error(`Invalid processId: ${selector.processId}`);
+    }
+    // `kill -0` is a portable existence probe on POSIX; on Windows we
+    // skip the check (the underlying debugger will reject a missing PID).
+    if (process.platform !== "win32") {
+      try {
+        process.kill(selector.processId, 0);
+      } catch (err) {
+        const hint = checkPtraceScopeHint();
+        const tail = hint ? ` ${hint}` : "";
+        throw new Error(
+          `Cannot attach to PID ${selector.processId}: ${(err as NodeJS.ErrnoException).message}.${tail}`,
+        );
+      }
+    }
+    return selector.processId;
+  }
+
+  if (selector.processName !== undefined) {
+    const candidates = findProcesses({ name: selector.processName }).filter(
+      // Skip ourselves so users cannot accidentally attach to mythosdbg.
+      (p) => p.pid !== process.pid,
+    );
+    if (candidates.length === 0) {
+      throw new Error(
+        `No running process matches '${selector.processName}'. Pass a numeric processId, or start the program first.`,
+      );
+    }
+    if (candidates.length > 1) {
+      const list = candidates
+        .slice(0, 8)
+        .map((p) => `pid=${p.pid} name=${p.name}`)
+        .join(", ");
+      throw new Error(
+        `Multiple processes match '${selector.processName}': ${list}${candidates.length > 8 ? ", …" : ""}. Pass a numeric processId.`,
+      );
+    }
+    return candidates[0].pid;
+  }
+
+  throw new Error("attach requires either processId or processName.");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,16 @@
 export { MythosSession } from "./core/mythosSession.js";
 export { HandlePool } from "./core/handles.js";
+export {
+  findProcesses,
+  listProcesses,
+  resolveAttachPid,
+  checkPtraceScopeHint,
+} from "./core/processes.js";
+export type {
+  ProcessInfo,
+  FindProcessesQuery,
+  AttachSelector,
+} from "./core/processes.js";
 export type { Runtime, LaunchArguments } from "./core/runtime.js";
 export { EchoRuntime } from "./runtimes/echo.js";
 export { CppLldbRuntime } from "./runtimes/cppLldb.js";

--- a/src/runtimes/cppLldb.ts
+++ b/src/runtimes/cppLldb.ts
@@ -3,6 +3,7 @@ import { Buffer } from "node:buffer";
 import path from "node:path";
 import type { DebugProtocol } from "@vscode/debugprotocol";
 import type { Runtime, LaunchArguments } from "../core/runtime";
+import { resolveAttachPid } from "../core/processes.js";
 
 /**
  * C/C++ runtime — wraps `lldb-dap` (LLVM 18+'s official DAP server)
@@ -65,7 +66,7 @@ export class CppLldbRuntime implements Runtime {
     });
     this.child.once("exit", (code) => {
       // Reject all pending requests with a descriptive error
-      for (const [seq, slot] of this.pending.entries()) {
+      for (const [, slot] of this.pending.entries()) {
         slot.reject(new Error(`lldb-dap exited with code ${code ?? "unknown"} while '${slot.command}' was pending`));
       }
       this.pending.clear();
@@ -107,7 +108,21 @@ export class CppLldbRuntime implements Runtime {
       linesStartAt1: true,
       columnsStartAt1: true,
     });
-    await this.request("launch", this.config);
+    if (this.config.request === "attach") {
+      // Resolve any user-supplied processName / processId into a
+      // concrete PID before forwarding to lldb-dap. This gives us
+      // consistent error messages (with ptrace_scope hints on Linux)
+      // across runtimes; lldb-dap accepts `pid` on its attach body.
+      const pid = resolveAttachPid({
+        processId: this.config.processId as number | undefined,
+        processName: this.config.processName as string | undefined,
+      });
+      const attachBody: Record<string, unknown> = { ...this.config, pid };
+      delete attachBody.processName;
+      await this.request("attach", attachBody);
+    } else {
+      await this.request("launch", this.config);
+    }
   }
 
   async handle(command: string, args: unknown): Promise<unknown> {
@@ -117,7 +132,11 @@ export class CppLldbRuntime implements Runtime {
   async dispose(): Promise<void> {
     if (!this.child) return;
     try {
-      await this.request("disconnect", { terminateDebuggee: true });
+      await this.request("disconnect", {
+        // attach sessions must NOT kill the debuggee by default —
+        // see issue mythosdbg#3.
+        terminateDebuggee: this.config.request !== "attach",
+      });
     } catch {
       /* ignore — adapter may already have torn down */
     }

--- a/tests/processes.test.ts
+++ b/tests/processes.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  parsePosixPs,
+  parseWindowsTasklist,
+  resolveAttachPid,
+  findProcesses,
+} from "../src/core/processes";
+
+describe("parsePosixPs", () => {
+  it("parses well-formed `ps -eo pid=,user=,comm=,args=` output", () => {
+    const sample = [
+      "    1 root             /sbin/launchd     /sbin/launchd",
+      "  421 logos            node              /usr/bin/node /opt/app/server.js --port 8080",
+      " 9999 logos            mythosdbg         node /opt/mythos/dist/server.js",
+      "",
+    ].join("\n");
+    const procs = parsePosixPs(sample);
+    expect(procs.map((p) => p.pid)).toEqual([1, 421, 9999]);
+    expect(procs[1].name).toBe("node");
+    expect(procs[1].command).toContain("server.js");
+    expect(procs[1].user).toBe("logos");
+  });
+
+  it("strips path components from the comm column", () => {
+    const sample = "  77 ci /usr/local/bin/dlv /usr/local/bin/dlv dap";
+    const [p] = parsePosixPs(sample);
+    expect(p.name).toBe("dlv");
+    expect(p.command).toBe("/usr/local/bin/dlv dap");
+  });
+
+  it("ignores blank and malformed lines", () => {
+    const sample = ["", "not a process line at all", "  42 user comm args here"].join("\n");
+    const procs = parsePosixPs(sample);
+    expect(procs).toHaveLength(1);
+    expect(procs[0].pid).toBe(42);
+  });
+});
+
+describe("parseWindowsTasklist", () => {
+  it("parses `tasklist /FO CSV /NH` lines", () => {
+    const sample = [
+      '"System Idle Process","0","Services","0","8 K"',
+      '"node.exe","12345","Console","1","45,123 K"',
+      '"my,process.exe","678","Console","1","100 K"',
+      "",
+    ].join("\r\n");
+    const procs = parseWindowsTasklist(sample);
+    expect(procs.map((p) => p.pid)).toEqual([0, 12345, 678]);
+    expect(procs[1].name).toBe("node.exe");
+    // Embedded comma in the image name should be preserved.
+    expect(procs[2].name).toBe("my,process.exe");
+  });
+});
+
+describe("resolveAttachPid", () => {
+  it("returns the explicit PID when it exists (we are alive)", () => {
+    expect(resolveAttachPid({ processId: process.pid })).toBe(process.pid);
+  });
+
+  it("rejects negative or non-numeric PIDs", () => {
+    expect(() => resolveAttachPid({ processId: -1 })).toThrow(/Invalid processId/);
+    expect(() => resolveAttachPid({ processId: Number.NaN })).toThrow(/Invalid processId/);
+  });
+
+  it("requires either processId or processName", () => {
+    expect(() => resolveAttachPid({})).toThrow(/processId or processName/);
+  });
+
+  it("rejects PIDs that don't exist on POSIX", () => {
+    if (process.platform === "win32") return;
+    // PID 0xFFFFF is reliably free on every modern POSIX kernel.
+    expect(() => resolveAttachPid({ processId: 0xfffff })).toThrow(/Cannot attach/);
+  });
+});
+
+describe("findProcesses (live)", () => {
+  it("can locate the current Node process by PID", () => {
+    if (process.platform === "win32") return; // tasklist may be slow in CI; PID-only path is enough
+    const found = findProcesses({ pid: process.pid });
+    expect(found.length).toBeGreaterThanOrEqual(1);
+    expect(found[0].pid).toBe(process.pid);
+  });
+});


### PR DESCRIPTION
## Summary

- Wires a real `attach` path that previously fell through the `launch` handler.
- New `src/core/processes.ts`:
  - `findProcesses({ pid?, name? })` — snapshots running processes via `ps` (POSIX) or `tasklist /FO CSV /NH` (Windows), returning a uniform `ProcessInfo` shape.
  - `resolveAttachPid({ processId?, processName? })` — validates an explicit PID with a portable `kill(0)` liveness probe, or matches an executable basename/substring against the process list (multi-match throws with the candidate list so the IDE can render a picker).
  - `checkPtraceScopeHint()` — reads `/proc/sys/kernel/yama/ptrace_scope` on Linux and folds a non-zero value into the attach error as an actionable `sudo` / `tee` hint.
- `cppLldb` now branches on `request === \"attach\"`, computes `pid` via `resolveAttachPid`, and forwards the resolved body to `lldb-dap`.
- `terminateDebuggee` defaults to `false` on disconnect for attach sessions, fulfilling the spec's \"leave the debuggee alive\" guarantee.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 11 passed (POSIX `ps` parser, Windows `tasklist` CSV parser, PID liveness probe, missing-PID error)
- [ ] Manual: `mythos-cpp` attach to a running `./hello` succeeds; disconnect leaves the process alive
- [ ] Manual: Linux host with `ptrace_scope=1` surfaces the ptrace hint in the launch error

Closes #3.