### PR TITLE
feat(transport): remote debugging over TCP and SSH stdio tunnels

### DIFF
--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -1,0 +1,317 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { Socket, connect as netConnect } from "node:net";
+import { Buffer } from "node:buffer";
+
+/**
+ * Transport abstraction for DAP byte streams.
+ *
+ * A transport hides the difference between:
+ *   - a locally spawned debugger subprocess that speaks DAP over its
+ *     own stdio (today's `cppLldb` behavior),
+ *   - a TCP connection to a remote `lldb-server` / `gdbserver` /
+ *     debugpy `--listen` endpoint,
+ *   - an SSH stdio tunnel (`ssh -W host:port user@gateway`) that
+ *     proxies the same TCP target without requiring a local listener
+ *     or a separate port-forward step.
+ *
+ * The interface is deliberately tiny — the consumer (each runtime's
+ * framing/dispatch loop) only needs `write` to push frames out and
+ * a `data` event source to read frames in. `close()` releases all
+ * underlying handles.
+ *
+ * Adding a new transport (e.g. a WebSocket URL the user pastes into
+ * launch.json) only requires implementing `DapTransport`.
+ */
+
+export interface DapTransport {
+  /** Write a chunk of DAP bytes (already framed) to the remote end. */
+  write(chunk: Buffer | string): void;
+  /** Subscribe to inbound bytes. Multiple subscribers are fine. */
+  onData(listener: (chunk: Buffer) => void): void;
+  /** Subscribe to fatal errors. The transport may be unusable after firing. */
+  onError(listener: (err: Error) => void): void;
+  /** Subscribe to remote-initiated close. */
+  onClose(listener: (info: { code?: number | null; reason?: string }) => void): void;
+  /** Tear down the transport. Idempotent. */
+  close(): void;
+}
+
+/* --------------------------------------------------------------- */
+/* Subprocess                                                       */
+/* --------------------------------------------------------------- */
+
+export interface SubprocessTransportOptions {
+  command: string;
+  args?: readonly string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export function createSubprocessTransport(
+  options: SubprocessTransportOptions,
+): DapTransport & { stderr?: NodeJS.ReadableStream; child: ChildProcess } {
+  const child = spawn(options.command, options.args ? [...options.args] : [], {
+    stdio: ["pipe", "pipe", "pipe"],
+    cwd: options.cwd,
+    env: options.env ? { ...process.env, ...options.env } : process.env,
+  });
+  const dataListeners: Array<(chunk: Buffer) => void> = [];
+  const errorListeners: Array<(err: Error) => void> = [];
+  const closeListeners: Array<(info: { code?: number | null }) => void> = [];
+
+  child.stdout?.on("data", (c: Buffer) => {
+    for (const l of dataListeners) l(c);
+  });
+  child.once("error", (err) => {
+    for (const l of errorListeners) l(err);
+  });
+  child.once("exit", (code) => {
+    for (const l of closeListeners) l({ code });
+  });
+
+  return {
+    child,
+    stderr: child.stderr ?? undefined,
+    write(chunk) {
+      child.stdin?.write(chunk);
+    },
+    onData(l) {
+      dataListeners.push(l);
+    },
+    onError(l) {
+      errorListeners.push(l);
+    },
+    onClose(l) {
+      closeListeners.push(l);
+    },
+    close() {
+      try {
+        child.kill();
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+/* --------------------------------------------------------------- */
+/* TCP                                                              */
+/* --------------------------------------------------------------- */
+
+export interface TcpTransportOptions {
+  host: string;
+  port: number;
+  /** Connect timeout in milliseconds; default 10s. */
+  timeoutMs?: number;
+}
+
+export async function createTcpTransport(
+  options: TcpTransportOptions,
+): Promise<DapTransport & { socket: Socket }> {
+  const socket = await connectSocket(options);
+  return wrapSocket(socket, () => `tcp://${options.host}:${options.port}`);
+}
+
+function connectSocket(options: TcpTransportOptions): Promise<Socket> {
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  return new Promise<Socket>((resolve, reject) => {
+    const sock = netConnect({ host: options.host, port: options.port });
+    const timer = setTimeout(() => {
+      sock.destroy(new Error(`Timed out connecting to ${options.host}:${options.port} after ${timeoutMs}ms`));
+    }, timeoutMs);
+    sock.once("connect", () => {
+      clearTimeout(timer);
+      resolve(sock);
+    });
+    sock.once("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+function wrapSocket(
+  socket: Socket,
+  describe: () => string,
+): DapTransport & { socket: Socket } {
+  const dataListeners: Array<(chunk: Buffer) => void> = [];
+  const errorListeners: Array<(err: Error) => void> = [];
+  const closeListeners: Array<(info: { reason?: string }) => void> = [];
+
+  socket.on("data", (c: Buffer) => {
+    for (const l of dataListeners) l(c);
+  });
+  socket.once("error", (err) => {
+    for (const l of errorListeners) l(err);
+  });
+  socket.once("close", () => {
+    for (const l of closeListeners) l({ reason: `${describe()} closed` });
+  });
+
+  return {
+    socket,
+    write(chunk) {
+      socket.write(chunk);
+    },
+    onData(l) {
+      dataListeners.push(l);
+    },
+    onError(l) {
+      errorListeners.push(l);
+    },
+    onClose(l) {
+      closeListeners.push(l);
+    },
+    close() {
+      try {
+        socket.destroy();
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+/* --------------------------------------------------------------- */
+/* SSH                                                              */
+/* --------------------------------------------------------------- */
+
+export interface SshTransportOptions {
+  /** SSH login host, e.g. "user@bastion" or "bastion". */
+  sshHost: string;
+  /** Optional SSH user (omit when sshHost already encodes it). */
+  sshUser?: string;
+  /** Final TCP target reachable from the SSH host. */
+  host: string;
+  port: number;
+  /** Path to a private key file (forwarded as `-i`). */
+  identityFile?: string;
+  /**
+   * Extra arguments passed to `ssh` after our defaults, useful for
+   * `-p`, `-J`, `-o ProxyCommand=…`, etc.
+   */
+  extraArgs?: readonly string[];
+  /** Optional override for the ssh executable (default: `ssh`). */
+  sshCommand?: string;
+}
+
+/**
+ * SSH stdio tunnel: spawns `ssh -W host:port [-i key] [user@]hostname`
+ * and treats its stdio as the DAP byte stream. This is functionally
+ * equivalent to running `lldb-server platform --listen *:port` on the
+ * remote host and connecting TCP, but does not require a publicly
+ * reachable port — the bytes flow over the existing SSH connection.
+ *
+ * `ssh -W` is supported by OpenSSH 5.4+ which is universal in
+ * practice. We forward stderr to the caller so authentication
+ * prompts and errors land in the workbench's debug console.
+ */
+export function createSshTransport(
+  options: SshTransportOptions,
+): DapTransport & { stderr: NodeJS.ReadableStream } {
+  const target = options.sshUser ? `${options.sshUser}@${options.sshHost}` : options.sshHost;
+  const args: string[] = [];
+  if (options.identityFile) args.push("-i", options.identityFile);
+  // -T disables pseudo-terminal allocation (we are not interactive).
+  // -o BatchMode=yes prevents ssh from blocking on a password prompt
+  // when no key/agent matches; users who need password auth can
+  // unset this through extraArgs.
+  args.push("-T", "-o", "BatchMode=yes");
+  args.push("-W", `${options.host}:${options.port}`);
+  if (options.extraArgs) args.push(...options.extraArgs);
+  args.push(target);
+
+  const child = spawn(options.sshCommand ?? "ssh", args, {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const dataListeners: Array<(chunk: Buffer) => void> = [];
+  const errorListeners: Array<(err: Error) => void> = [];
+  const closeListeners: Array<(info: { code?: number | null }) => void> = [];
+
+  child.stdout?.on("data", (c: Buffer) => {
+    for (const l of dataListeners) l(c);
+  });
+  child.once("error", (err) => {
+    for (const l of errorListeners) l(err);
+  });
+  child.once("exit", (code) => {
+    for (const l of closeListeners) l({ code });
+  });
+
+  if (!child.stderr) {
+    throw new Error("ssh subprocess has no stderr; cannot proxy diagnostics");
+  }
+
+  return {
+    stderr: child.stderr,
+    write(chunk) {
+      child.stdin?.write(chunk);
+    },
+    onData(l) {
+      dataListeners.push(l);
+    },
+    onError(l) {
+      errorListeners.push(l);
+    },
+    onClose(l) {
+      closeListeners.push(l);
+    },
+    close() {
+      try {
+        child.kill();
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+/* --------------------------------------------------------------- */
+/* launch.json mapping                                              */
+/* --------------------------------------------------------------- */
+
+export interface RemoteLaunchBlock {
+  host: string;
+  port: number;
+  transport?: "tcp" | "ssh";
+  sshHost?: string;
+  sshUser?: string;
+  identityFile?: string;
+  sshArgs?: string[];
+  timeoutMs?: number;
+}
+
+/**
+ * Build a transport from a launch.json `remote` block. The runtime
+ * stays oblivious to which kind of remote we picked.
+ *
+ * Exported for use by every runtime that has a remote story
+ * (cppLldb today, debugpy `--listen` next).
+ */
+export async function createRemoteTransport(
+  remote: RemoteLaunchBlock,
+): Promise<DapTransport> {
+  const transport = remote.transport ?? "tcp";
+  if (transport === "tcp") {
+    return createTcpTransport({
+      host: remote.host,
+      port: remote.port,
+      timeoutMs: remote.timeoutMs,
+    });
+  }
+  if (transport === "ssh") {
+    if (!remote.sshHost) {
+      throw new Error("remote.transport=ssh requires remote.sshHost");
+    }
+    return createSshTransport({
+      sshHost: remote.sshHost,
+      sshUser: remote.sshUser,
+      host: remote.host,
+      port: remote.port,
+      identityFile: remote.identityFile,
+      extraArgs: remote.sshArgs,
+    });
+  }
+  throw new Error(`Unknown remote transport '${String(transport)}'`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,18 @@
 export { MythosSession } from "./core/mythosSession.js";
 export { HandlePool } from "./core/handles.js";
+export {
+  createSubprocessTransport,
+  createTcpTransport,
+  createSshTransport,
+  createRemoteTransport,
+} from "./core/transport.js";
+export type {
+  DapTransport,
+  SubprocessTransportOptions,
+  TcpTransportOptions,
+  SshTransportOptions,
+  RemoteLaunchBlock,
+} from "./core/transport.js";
 export type { Runtime, LaunchArguments } from "./core/runtime.js";
 export { EchoRuntime } from "./runtimes/echo.js";
 export { CppLldbRuntime } from "./runtimes/cppLldb.js";

--- a/src/runtimes/cppLldb.ts
+++ b/src/runtimes/cppLldb.ts
@@ -1,23 +1,32 @@
-import { spawn, type ChildProcess, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { Buffer } from "node:buffer";
 import path from "node:path";
 import type { DebugProtocol } from "@vscode/debugprotocol";
 import type { Runtime, LaunchArguments } from "../core/runtime";
+import {
+  createSubprocessTransport,
+  createRemoteTransport,
+  type DapTransport,
+  type RemoteLaunchBlock,
+} from "../core/transport.js";
 
 /**
  * C/C++ runtime — wraps `lldb-dap` (LLVM 18+'s official DAP server)
- * as a child process and proxies DAP frames. The wrapper is what
- * gives Mythos a place to add value-add features later (custom
- * source mapping, snapshot capture, distributed debug, …) without
- * forking lldb.
+ * and proxies DAP frames. The wrapper gives Mythos a place to add
+ * value-add features later (custom source mapping, snapshot capture,
+ * distributed debug, …) without forking lldb.
  *
- * Discovery order:
+ * Connection mode is decided by the launch config:
+ *   - `config.remote` present → use a TCP / SSH transport from
+ *     `core/transport.ts`. Useful when the binary actually lives on
+ *     another host (`lldb-server platform --listen *:1234`,
+ *     `gdbserver :1234 ./hello`, …).
+ *   - Otherwise → spawn `lldb-dap` locally and use its stdio.
+ *
+ * Local discovery order:
  *   1. `config.debugAdapter` if the user pins one in launch.json
  *   2. `lldb-dap` on PATH
  *   3. `xcrun --find lldb-dap` (macOS only)
- *
- * If none resolve, `start()` rejects with a helpful error so the
- * Mythos session surfaces it as an unsuccessful `launch` response.
  *
  * Tracking issue (mythosdbg): Windows support (cdb / windbg) is not
  * implemented. See the Stage 3.5 plan H.4 for the open issue list.
@@ -35,7 +44,7 @@ type Pending = {
 
 export class CppLldbRuntime implements Runtime {
   readonly id = "mythos-cpp";
-  private child: ChildProcess | null = null;
+  private transport: DapTransport | null = null;
   private buffer: Buffer = Buffer.alloc(0);
   private nextSeq = 1;
   private readonly pending = new Map<number, Pending>();
@@ -48,37 +57,34 @@ export class CppLldbRuntime implements Runtime {
 
   async start(emit: (evt: DebugProtocol.Event) => void): Promise<void> {
     this.emit = emit;
-    const command = await this.resolveAdapter();
-    this.child = spawn(command, [], {
-      stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, ...((this.config.env as Record<string, string>) ?? {}) },
-      cwd: this.config.cwd,
-    });
-    this.child.stdout?.on("data", (chunk: Buffer) => this.feed(chunk));
-    this.child.stderr?.on("data", (chunk: Buffer) => {
+    this.transport = await this.openTransport();
+    this.transport.onData((chunk) => this.feed(chunk));
+    this.transport.onError((err) => {
       this.emit?.({
         seq: 0,
         type: "event",
         event: "output",
-        body: { category: "stderr", output: chunk.toString("utf8") },
+        body: { category: "stderr", output: `lldb-dap transport error: ${err.message}\n` },
       } as DebugProtocol.OutputEvent);
-    });
-    this.child.once("exit", (code) => {
-      // Reject all pending requests with a descriptive error
-      for (const [seq, slot] of this.pending.entries()) {
-        slot.reject(new Error(`lldb-dap exited with code ${code ?? "unknown"} while '${slot.command}' was pending`));
+      for (const [, slot] of this.pending.entries()) {
+        slot.reject(new Error(`lldb-dap transport failed ('${slot.command}' pending): ${err.message}`));
       }
       this.pending.clear();
-
+    });
+    this.transport.onClose((info) => {
+      const desc = "code" in info && info.code != null
+        ? `code=${info.code}`
+        : info.reason ?? "closed";
+      for (const [, slot] of this.pending.entries()) {
+        slot.reject(new Error(`lldb-dap transport closed (${desc}) while '${slot.command}' was pending`));
+      }
+      this.pending.clear();
       if (this.emit) {
         this.emit({
           seq: 0,
           type: "event",
           event: "output",
-          body: {
-            category: "console",
-            output: `lldb-dap exited (code=${code ?? "?"})\n`,
-          },
+          body: { category: "console", output: `lldb-dap transport closed (${desc})\n` },
         } as DebugProtocol.OutputEvent);
         this.emit({
           seq: 0,
@@ -86,18 +92,7 @@ export class CppLldbRuntime implements Runtime {
           event: "terminated",
         } as DebugProtocol.TerminatedEvent);
       }
-      this.child = null;
-    });
-    this.child.once("error", (err) => {
-      this.emit?.({
-        seq: 0,
-        type: "event",
-        event: "output",
-        body: {
-          category: "stderr",
-          output: `lldb-dap error: ${err.message}\n`,
-        },
-      } as DebugProtocol.OutputEvent);
+      this.transport = null;
     });
 
     await this.request("initialize", {
@@ -115,21 +110,50 @@ export class CppLldbRuntime implements Runtime {
   }
 
   async dispose(): Promise<void> {
-    if (!this.child) return;
+    if (!this.transport) return;
     try {
       await this.request("disconnect", { terminateDebuggee: true });
     } catch {
       /* ignore — adapter may already have torn down */
     }
-    if (this.child && this.child.exitCode === null) {
+    try {
+      this.transport.close();
+    } catch {
+      /* ignore */
+    }
+    this.transport = null;
+    this.emit = null;
+  }
+
+  /** Open the right transport for this launch configuration. */
+  private async openTransport(): Promise<DapTransport> {
+    const remote = this.config.remote as RemoteLaunchBlock | undefined;
+    if (remote && typeof remote === "object") {
       try {
-        this.child.kill();
-      } catch {
-        /* ignore */
+        return await createRemoteTransport(remote);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`Could not open remote DAP transport: ${message}`);
       }
     }
-    this.child = null;
-    this.emit = null;
+
+    const command = await this.resolveAdapter();
+    const subprocess = createSubprocessTransport({
+      command,
+      env: (this.config.env as Record<string, string> | undefined) ?? undefined,
+      cwd: this.config.cwd,
+    });
+    // Forward lldb-dap's stderr verbatim — it carries crash diagnostics
+    // we never want to swallow.
+    subprocess.stderr?.on("data", (chunk: Buffer) => {
+      this.emit?.({
+        seq: 0,
+        type: "event",
+        event: "output",
+        body: { category: "stderr", output: chunk.toString("utf8") },
+      } as DebugProtocol.OutputEvent);
+    });
+    return subprocess;
   }
 
   private async resolveAdapter(): Promise<string> {
@@ -214,7 +238,7 @@ export class CppLldbRuntime implements Runtime {
   }
 
   private request(command: string, args: unknown): Promise<unknown> {
-    if (!this.child) return Promise.reject(new Error("lldb-dap is not running"));
+    if (!this.transport) return Promise.reject(new Error("lldb-dap transport is not open"));
     const seq = this.nextSeq++;
     const req: DebugProtocol.Request = {
       seq,
@@ -236,8 +260,8 @@ export class CppLldbRuntime implements Runtime {
   private write(msg: DebugProtocol.ProtocolMessage): void {
     const body = JSON.stringify(msg);
     const head = `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n`;
-    this.child?.stdin?.write(head);
-    this.child?.stdin?.write(body, "utf8");
+    this.transport?.write(head);
+    this.transport?.write(body);
   }
 }
 

--- a/tests/transport.test.ts
+++ b/tests/transport.test.ts
@@ -1,0 +1,118 @@
+import { createServer, Socket } from "node:net";
+import { describe, expect, it } from "vitest";
+import {
+  createTcpTransport,
+  createSubprocessTransport,
+  createRemoteTransport,
+  type DapTransport,
+} from "../src/core/transport";
+
+/**
+ * Transport tests use a tiny in-process TCP echo server to exercise
+ * the TCP path end-to-end without depending on external tools. The
+ * SSH path cannot be unit-tested without a real ssh client; we verify
+ * shape only (validation rejects when sshHost is missing, etc.).
+ */
+
+function startEchoServer(): Promise<{ port: number; close: () => void }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((sock: Socket) => {
+      sock.on("data", (chunk) => sock.write(chunk));
+    });
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (typeof addr === "object" && addr) {
+        resolve({ port: addr.port, close: () => server.close() });
+      } else {
+        reject(new Error("listen returned no address"));
+      }
+    });
+  });
+}
+
+async function readOnce(t: DapTransport, timeoutMs = 1_000): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("timeout")), timeoutMs);
+    t.onData((chunk) => {
+      clearTimeout(timer);
+      resolve(chunk);
+    });
+    t.onError((err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+describe("createTcpTransport", () => {
+  it("connects, round-trips bytes, and closes cleanly", async () => {
+    const server = await startEchoServer();
+    try {
+      const t = await createTcpTransport({ host: "127.0.0.1", port: server.port });
+      const reply = readOnce(t);
+      t.write(Buffer.from("hello"));
+      expect((await reply).toString()).toBe("hello");
+      t.close();
+    } finally {
+      server.close();
+    }
+  });
+
+  it("rejects when the host is unreachable", async () => {
+    // Port 1 is privileged and never has a listener in test envs.
+    await expect(
+      createTcpTransport({ host: "127.0.0.1", port: 1, timeoutMs: 250 }),
+    ).rejects.toBeDefined();
+  });
+});
+
+describe("createSubprocessTransport", () => {
+  it("spawns a process and surfaces its stdout via onData", async () => {
+    const t = createSubprocessTransport({
+      command: process.execPath,
+      args: ["-e", "process.stdout.write('hi'); setTimeout(()=>process.exit(0), 50)"],
+    });
+    const buf = await readOnce(t);
+    expect(buf.toString()).toBe("hi");
+    t.close();
+  });
+});
+
+describe("createRemoteTransport", () => {
+  it("dispatches to TCP by default", async () => {
+    const server = await startEchoServer();
+    try {
+      const t = await createRemoteTransport({
+        host: "127.0.0.1",
+        port: server.port,
+      });
+      const reply = readOnce(t);
+      t.write(Buffer.from("ping"));
+      expect((await reply).toString()).toBe("ping");
+      t.close();
+    } finally {
+      server.close();
+    }
+  });
+
+  it("rejects ssh transport without sshHost", async () => {
+    await expect(
+      createRemoteTransport({
+        host: "10.0.0.1",
+        port: 1234,
+        transport: "ssh",
+      }),
+    ).rejects.toThrow(/sshHost/);
+  });
+
+  it("rejects unknown transport name", async () => {
+    await expect(
+      createRemoteTransport({
+        host: "10.0.0.1",
+        port: 1234,
+        transport: "websocket" as unknown as "tcp",
+      }),
+    ).rejects.toThrow(/Unknown remote transport/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a tiny `DapTransport` abstraction so runtimes can speak DAP to either a local subprocess, a TCP listener, or an SSH stdio tunnel.
- New `src/core/transport.ts` exports `createSubprocessTransport`, `createTcpTransport`, `createSshTransport`, and a `createRemoteTransport(remoteBlock)` dispatcher keyed off launch.json's `remote: { host, port, transport: \"tcp\" | \"ssh\", sshHost?, sshUser?, identityFile?, sshArgs?, timeoutMs? }`.
- The SSH path uses `ssh -W host:port [user@]gateway` so the user does not need a publicly reachable port or a separate `-L` forward step — bytes flow over the existing SSH connection's stdio.
- `cppLldb` migrates onto the transport: the local-subprocess path becomes one branch; `config.remote` triggers the remote branch.
- Connection failures surface as DAP `output` events with actionable messages.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 8 passed; in-process TCP echo server exercises the TCP path end-to-end; the launch-block dispatcher validates `sshHost` requirement and rejects unknown transports
- [ ] Manual: `lldb-server platform --listen *:1234` on a remote host; `mythos-cpp` debugs through it
- [ ] Manual: SSH stdio tunnel against a bastion that forwards to a private debug port

Closes #4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增远程调试支持：现可通过TCP协议或SSH隧道连接到远程调试器，扩展了调试适配器的使用场景
  * 改进的传输层架构：统一了本地进程、远程TCP和SSH隧道的调试连接方式

<!-- end of auto-generated comment: release notes by coderabbit.ai -->