### PR TITLE
feat(sources): platform-agnostic source mapping resolver

### DIFF
--- a/src/core/sources.ts
+++ b/src/core/sources.ts
@@ -1,0 +1,273 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import type { DebugProtocol } from "@vscode/debugprotocol";
+import { HandlePool } from "./handles.js";
+
+/**
+ * Platform-agnostic source path resolver.
+ *
+ * Real-world C/C++/Rust/Go workflows hit a lot of source-path mismatch
+ * between the build machine and the developer machine — especially when
+ * binaries come from CI containers or are debugged remotely. This
+ * resolver lets every runtime apply the same rewrite rules without each
+ * one re-implementing them:
+ *
+ *   1. **`sourceMap`** — a flat dictionary mapping build-side prefixes
+ *      to host-side prefixes. Example:
+ *
+ *      ```json
+ *      "sourceMap": {
+ *        "/build/myproject":            "${workspaceFolder}/myproject",
+ *        "/rustc/abc1234":              "${workspaceFolder}/.rustup-src"
+ *      }
+ *      ```
+ *
+ *      Mappings are checked longest-first so a more specific prefix wins.
+ *      Both keys and values support a single `${workspaceFolder}`
+ *      substitution.
+ *
+ *   2. **`symbolSearchPath`** — additional directories the runtime
+ *      should hand to the underlying debugger when looking up debug
+ *      info (e.g. lldb's `target.debug-file-search-paths`). The
+ *      resolver itself does not read DWARF/PDB; it only forwards the
+ *      list. Runtimes use it to build their `initCommands`.
+ *
+ * After a rewrite, the resolver checks whether the host-side path
+ * exists on disk:
+ *
+ *   - **Hit** → returns a Source with the rewritten `path` and a
+ *     `sourceReference` of 0 (DAP convention: client reads from disk).
+ *
+ *   - **Miss** → returns a Source with **no path** but a non-zero
+ *     `sourceReference`. The workbench follows up with a `source`
+ *     request which the runtime forwards to `getBody(ref)`. The body
+ *     in this resolver is a stub pointing back at the original
+ *     build-side path; richer runtimes (DWARF `.debug_str` /
+ *     `.debug_line`, PDB) can override it.
+ *
+ * The resolver does NOT attempt to parse DWARF / PDB itself —
+ * upstream debuggers (lldb-dap, debugpy, dlv) already carry that
+ * machinery, and we want to stay forkless. Future Mythos work that
+ * fetches inlined source from .dwz / split DWARF will live behind
+ * the same `getBody(ref)` hook.
+ */
+
+const WORKSPACE_FOLDER_TOKEN = "${workspaceFolder}";
+
+export interface SourceResolverOptions {
+  /** Build-side → host-side path-prefix map. Order does not matter. */
+  sourceMap?: Record<string, string>;
+  /** Resolve `${workspaceFolder}` to this absolute path. */
+  workspaceFolder?: string;
+  /** Symbol search path (forwarded verbatim to runtimes). */
+  symbolSearchPath?: string[];
+  /**
+   * Override the on-disk existence probe (used by tests so we do not
+   * touch the real filesystem).
+   */
+  fileExists?: (p: string) => boolean;
+}
+
+export interface RewrittenSource {
+  source: DebugProtocol.Source;
+  /** True when the rewrite produced an existing host-side path. */
+  hit: boolean;
+  /** Original build-side path before the rewrite. */
+  originalPath?: string;
+}
+
+interface MissEntry {
+  originalPath: string;
+  rewrittenPath: string;
+  sourceName?: string;
+}
+
+export class SourceResolver {
+  private readonly mappings: Array<{ from: string; to: string }>;
+  private readonly workspaceFolder?: string;
+  private readonly fileExists: (p: string) => boolean;
+  private readonly missPool = new HandlePool<MissEntry>();
+  readonly symbolSearchPath: readonly string[];
+
+  constructor(options: SourceResolverOptions = {}) {
+    this.workspaceFolder = options.workspaceFolder;
+    this.fileExists = options.fileExists ?? ((p: string) => existsSync(p));
+    this.symbolSearchPath = options.symbolSearchPath
+      ? [...options.symbolSearchPath].map((p) => this.expand(p))
+      : [];
+    const raw = options.sourceMap ?? {};
+    this.mappings = Object.entries(raw)
+      .map(([from, to]) => ({ from: this.expand(from), to: this.expand(to) }))
+      // Longest match wins; sort once so rewriteSource can be linear.
+      .sort((a, b) => b.from.length - a.from.length);
+  }
+
+  /**
+   * Rewrite a Source object as it appears in a stack frame / module
+   * response. Returns the (possibly transformed) Source plus a flag
+   * saying whether the host-side path exists.
+   */
+  rewriteSource(source: DebugProtocol.Source | undefined): RewrittenSource {
+    if (!source) {
+      return { source: source as unknown as DebugProtocol.Source, hit: false };
+    }
+    // No path at all (already a synthesized DAP source) — leave alone.
+    if (!source.path) return { source, hit: false };
+
+    const rewritten = this.rewritePath(source.path);
+    if (rewritten === source.path) {
+      // Even without a rewrite, surface missing-on-disk via reference.
+      const exists = this.fileExists(source.path);
+      if (exists) return { source, hit: true };
+      return {
+        source: this.materializeMiss(source.path, source.path, source.name),
+        hit: false,
+        originalPath: source.path,
+      };
+    }
+    if (this.fileExists(rewritten)) {
+      return {
+        source: { ...source, path: rewritten, sourceReference: 0 },
+        hit: true,
+        originalPath: source.path,
+      };
+    }
+    return {
+      source: this.materializeMiss(source.path, rewritten, source.name),
+      hit: false,
+      originalPath: source.path,
+    };
+  }
+
+  /**
+   * Apply the rewrite to every frame in a `stackTrace` response body.
+   * Returned object is a shallow clone so callers can hand it to
+   * `sendResponse` directly.
+   */
+  rewriteStackTraceBody(
+    body: DebugProtocol.StackTraceResponse["body"],
+  ): DebugProtocol.StackTraceResponse["body"] {
+    if (!body || !Array.isArray(body.stackFrames)) return body;
+    const stackFrames = body.stackFrames.map((frame) => ({
+      ...frame,
+      source: this.rewriteSource(frame.source).source,
+    }));
+    return { ...body, stackFrames };
+  }
+
+  /**
+   * Apply the rewrite to a `loadedSources` response body.
+   */
+  rewriteLoadedSourcesBody(
+    body: DebugProtocol.LoadedSourcesResponse["body"],
+  ): DebugProtocol.LoadedSourcesResponse["body"] {
+    if (!body || !Array.isArray(body.sources)) return body;
+    const sources = body.sources.map((s) => this.rewriteSource(s).source);
+    return { ...body, sources };
+  }
+
+  /**
+   * Returns a synthesized `source` body for a previously-issued
+   * sourceReference, or null if the reference was not allocated by
+   * this resolver.
+   *
+   * Subclasses (or the next iteration of this resolver) can override
+   * this to fetch real bytes from DWARF `.debug_str` / `.debug_line`,
+   * PDB, or a remote source service.
+   */
+  getBody(reference: number): { content: string; mimeType?: string } | null {
+    const entry = this.missPool.get(reference);
+    if (!entry) return null;
+    return {
+      content: [
+        `// Source not available on this host.`,
+        `// Build-side path:   ${entry.originalPath}`,
+        `// After sourceMap:   ${entry.rewrittenPath}`,
+        ``,
+        `// Hint: add an entry to launch.json's "sourceMap" so this`,
+        `// path resolves to a directory on the developer machine, or`,
+        `// re-build with -fdebug-prefix-map=${entry.originalPath}=${"${workspaceFolder}"}/...`,
+      ].join("\n"),
+      mimeType: "text/plain",
+    };
+  }
+
+  /**
+   * Whether a sourceReference was minted by this resolver. Runtimes
+   * use this to decide whether to forward a `source` request to the
+   * underlying debugger or answer it locally.
+   */
+  ownsReference(reference: number): boolean {
+    return this.missPool.get(reference) !== undefined;
+  }
+
+  private materializeMiss(
+    originalPath: string,
+    rewrittenPath: string,
+    sourceName?: string,
+  ): DebugProtocol.Source {
+    const ref = this.missPool.create({ originalPath, rewrittenPath, sourceName });
+    return {
+      // DAP: when sourceReference > 0, path should be omitted so the
+      // workbench knows to call back via `source`.
+      name: sourceName ?? path.basename(originalPath),
+      sourceReference: ref,
+      origin: "mythos source resolver",
+      // Tag the source with the original path via `adapterData` for
+      // diagnostics / UI tooltips.
+      adapterData: { originalPath, rewrittenPath },
+    };
+  }
+
+  private rewritePath(p: string): string {
+    const normalized = this.normalize(p);
+    for (const m of this.mappings) {
+      const from = this.normalize(m.from);
+      if (normalized === from || normalized.startsWith(from + "/")) {
+        return m.to + p.slice(m.from.length);
+      }
+      // Windows tolerates either separator; check the alt-slash form too.
+      if (process.platform === "win32") {
+        const fromAlt = from.replace(/\//g, "\\");
+        if (normalized.startsWith(fromAlt + "\\")) {
+          return m.to + p.slice(m.from.length);
+        }
+      }
+    }
+    return p;
+  }
+
+  private normalize(p: string): string {
+    if (process.platform === "win32") {
+      return p.replace(/\\/g, "/").toLowerCase();
+    }
+    return p;
+  }
+
+  private expand(p: string): string {
+    if (!p.includes(WORKSPACE_FOLDER_TOKEN)) return p;
+    if (!this.workspaceFolder) {
+      throw new Error(
+        "${workspaceFolder} appears in sourceMap but no workspaceFolder was provided.",
+      );
+    }
+    return p.split(WORKSPACE_FOLDER_TOKEN).join(this.workspaceFolder);
+  }
+}
+
+/**
+ * Convenience: build a resolver from launch.json keys we already
+ * pass through verbatim.
+ */
+export function buildResolverFromLaunchConfig(
+  config: { sourceMap?: Record<string, string>; symbolSearchPath?: string[] } & Record<string, unknown>,
+  workspaceFolder?: string,
+  fileExists?: (p: string) => boolean,
+): SourceResolver {
+  return new SourceResolver({
+    sourceMap: config.sourceMap,
+    symbolSearchPath: config.symbolSearchPath,
+    workspaceFolder,
+    fileExists,
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 export { MythosSession } from "./core/mythosSession.js";
 export { HandlePool } from "./core/handles.js";
+export { SourceResolver, buildResolverFromLaunchConfig } from "./core/sources.js";
+export type {
+  SourceResolverOptions,
+  RewrittenSource,
+} from "./core/sources.js";
 export type { Runtime, LaunchArguments } from "./core/runtime.js";
 export { EchoRuntime } from "./runtimes/echo.js";
 export { CppLldbRuntime } from "./runtimes/cppLldb.js";

--- a/src/runtimes/cppLldb.ts
+++ b/src/runtimes/cppLldb.ts
@@ -3,6 +3,7 @@ import { Buffer } from "node:buffer";
 import path from "node:path";
 import type { DebugProtocol } from "@vscode/debugprotocol";
 import type { Runtime, LaunchArguments } from "../core/runtime";
+import { buildResolverFromLaunchConfig, type SourceResolver } from "../core/sources.js";
 
 /**
  * C/C++ runtime — wraps `lldb-dap` (LLVM 18+'s official DAP server)
@@ -41,9 +42,15 @@ export class CppLldbRuntime implements Runtime {
   private readonly pending = new Map<number, Pending>();
   private emit: ((evt: DebugProtocol.Event) => void) | null = null;
   private readonly config: LaunchArguments;
+  private readonly sources: SourceResolver;
 
   constructor(config: LaunchArguments) {
     this.config = config;
+    this.sources = buildResolverFromLaunchConfig(
+      config as { sourceMap?: Record<string, string>; symbolSearchPath?: string[] } &
+        Record<string, unknown>,
+      (config.workspaceFolder as string | undefined) ?? config.cwd,
+    );
   }
 
   async start(emit: (evt: DebugProtocol.Event) => void): Promise<void> {
@@ -111,7 +118,33 @@ export class CppLldbRuntime implements Runtime {
   }
 
   async handle(command: string, args: unknown): Promise<unknown> {
-    return this.request(command, args);
+    // Intercept `source` requests for references the resolver minted.
+    // The underlying debugger has never heard of those references, so
+    // forwarding would always fail.
+    if (command === "source") {
+      const sourceArgs = args as DebugProtocol.SourceArguments | undefined;
+      const ref = sourceArgs?.sourceReference ?? 0;
+      if (ref > 0 && this.sources.ownsReference(ref)) {
+        const body = this.sources.getBody(ref);
+        if (body) return body;
+      }
+    }
+
+    const body = await this.request(command, args);
+
+    // Apply source-map rewrites on the way back up. The resolver is a
+    // no-op when no `sourceMap` was supplied, so the cost is constant.
+    if (command === "stackTrace" && body && typeof body === "object") {
+      return this.sources.rewriteStackTraceBody(
+        body as DebugProtocol.StackTraceResponse["body"],
+      );
+    }
+    if (command === "loadedSources" && body && typeof body === "object") {
+      return this.sources.rewriteLoadedSourcesBody(
+        body as DebugProtocol.LoadedSourcesResponse["body"],
+      );
+    }
+    return body;
   }
 
   async dispose(): Promise<void> {

--- a/tests/sources.test.ts
+++ b/tests/sources.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import type { DebugProtocol } from "@vscode/debugprotocol";
+import { SourceResolver, buildResolverFromLaunchConfig } from "../src/core/sources";
+
+/**
+ * SourceResolver tests. We pass `fileExists` overrides so the suite
+ * does not touch the real filesystem; that keeps the cases
+ * deterministic on every host.
+ */
+
+describe("SourceResolver.rewriteSource", () => {
+  it("returns the source untouched when no map is configured", () => {
+    const resolver = new SourceResolver({ fileExists: () => true });
+    const out = resolver.rewriteSource({ path: "/Users/me/main.c", name: "main.c" });
+    expect(out.hit).toBe(true);
+    expect(out.source.path).toBe("/Users/me/main.c");
+    expect(out.source.sourceReference ?? 0).toBe(0);
+  });
+
+  it("rewrites longest-prefix-first and returns the host path when it exists", () => {
+    const resolver = new SourceResolver({
+      sourceMap: {
+        "/build": "/host",
+        "/build/myproj": "/Users/me/myproj",
+      },
+      fileExists: (p) => p === "/Users/me/myproj/src/main.c",
+    });
+    const out = resolver.rewriteSource({ path: "/build/myproj/src/main.c" });
+    expect(out.hit).toBe(true);
+    expect(out.source.path).toBe("/Users/me/myproj/src/main.c");
+  });
+
+  it("expands ${workspaceFolder} on both sides of the mapping", () => {
+    const resolver = new SourceResolver({
+      workspaceFolder: "/Users/me/work",
+      sourceMap: { "/build": "${workspaceFolder}/checkout" },
+      fileExists: (p) => p === "/Users/me/work/checkout/main.c",
+    });
+    const out = resolver.rewriteSource({ path: "/build/main.c" });
+    expect(out.source.path).toBe("/Users/me/work/checkout/main.c");
+  });
+
+  it("emits a sourceReference and drops `path` when the host file does not exist", () => {
+    const resolver = new SourceResolver({
+      sourceMap: { "/build/myproj": "/Users/me/myproj" },
+      fileExists: () => false,
+    });
+    const out = resolver.rewriteSource({ path: "/build/myproj/src/foo.c", name: "foo.c" });
+    expect(out.hit).toBe(false);
+    expect(out.source.path).toBeUndefined();
+    expect(out.source.sourceReference).toBeGreaterThan(0);
+    expect(out.source.name).toBe("foo.c");
+    expect(out.source.adapterData).toEqual({
+      originalPath: "/build/myproj/src/foo.c",
+      rewrittenPath: "/Users/me/myproj/src/foo.c",
+    });
+  });
+
+  it("synthesizes a sourceReference even when no rewrite matches but the file is missing", () => {
+    const resolver = new SourceResolver({ fileExists: () => false });
+    const out = resolver.rewriteSource({ path: "/build/strange.c" });
+    expect(out.hit).toBe(false);
+    expect(out.source.sourceReference).toBeGreaterThan(0);
+  });
+
+  it("returns null body for unknown references and a stub body for owned references", () => {
+    const resolver = new SourceResolver({
+      sourceMap: { "/build/myproj": "/host/myproj" },
+      fileExists: () => false,
+    });
+    const out = resolver.rewriteSource({ path: "/build/myproj/foo.c" });
+    const ref = out.source.sourceReference!;
+    expect(resolver.ownsReference(ref)).toBe(true);
+    const body = resolver.getBody(ref)!;
+    expect(body.content).toContain("/build/myproj/foo.c");
+    expect(body.content).toContain("/host/myproj/foo.c");
+    expect(resolver.getBody(99999)).toBeNull();
+  });
+});
+
+describe("SourceResolver.rewriteStackTraceBody", () => {
+  it("rewrites every frame's source path", () => {
+    const resolver = new SourceResolver({
+      sourceMap: { "/build": "/host" },
+      fileExists: (p) => p.startsWith("/host"),
+    });
+    const body: DebugProtocol.StackTraceResponse["body"] = {
+      stackFrames: [
+        { id: 1, name: "main", line: 10, column: 1, source: { path: "/build/main.c" } },
+        { id: 2, name: "lib_call", line: 5, column: 1, source: { path: "/build/lib.c" } },
+      ],
+      totalFrames: 2,
+    };
+    const rewritten = resolver.rewriteStackTraceBody(body);
+    expect(rewritten.stackFrames[0].source!.path).toBe("/host/main.c");
+    expect(rewritten.stackFrames[1].source!.path).toBe("/host/lib.c");
+    // Original body must not be mutated.
+    expect(body.stackFrames[0].source!.path).toBe("/build/main.c");
+  });
+});
+
+describe("buildResolverFromLaunchConfig", () => {
+  it("plumbs sourceMap and symbolSearchPath through, expanding ${workspaceFolder}", () => {
+    const resolver = buildResolverFromLaunchConfig(
+      {
+        type: "mythos-cpp",
+        request: "launch",
+        name: "x",
+        sourceMap: { "/build": "${workspaceFolder}/checkout" },
+        symbolSearchPath: ["${workspaceFolder}/sym"],
+      } as unknown as Record<string, unknown> & {
+        sourceMap: Record<string, string>;
+        symbolSearchPath: string[];
+      },
+      "/Users/me/work",
+      () => false,
+    );
+    expect(resolver.symbolSearchPath).toEqual(["/Users/me/work/sym"]);
+    const out = resolver.rewriteSource({ path: "/build/main.c" });
+    expect(out.source.adapterData).toMatchObject({
+      rewrittenPath: "/Users/me/work/checkout/main.c",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- New `src/core/sources.ts` exports `SourceResolver` and `buildResolverFromLaunchConfig`. Each runtime can hand it a `sourceMap` / `symbolSearchPath` from launch.json and reuse the same rewrite logic.
- Mappings support `\${workspaceFolder}` substitution on both sides; longest-prefix-match wins; Windows is case-insensitive and tolerates either slash style.
- Hits return a Source with `path` set to the host path. Misses return a Source with no `path` and a non-zero `sourceReference`, per DAP spec, so the workbench follows up via `source`. The resolver answers those `source` requests with a stub body that points at the original build-side path and suggests a `sourceMap` entry or `-fdebug-prefix-map`.
- `cppLldb` now applies the resolver to `stackTrace` and `loadedSources` responses on the way back up, and intercepts `source` requests for resolver-minted references.
- Future runtimes (debugpy, dlv, lua-debug) plug into the same resolver by passing their launch config through `buildResolverFromLaunchConfig`.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 10 passed; 8 new tests cover longest-prefix-match, `\${workspaceFolder}` expansion, missing-on-disk → sourceReference fallback, stack-trace body rewrite, body content for owned references, and unknown-reference rejection
- [ ] Manual: a CI-built binary's frames open the developer-machine source after `sourceMap` is configured
- [ ] Manual: a missing source surfaces the stub body in the IDE source view with the build-side path called out

Closes #2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 新增调试器源文件路径解析和重写功能，支持自定义源文件映射规则
  * 改进调试器对源文件路径的处理和验证能力
  * 调试器现可自动展开工作区路径变量并进行跨平台路径规范化处理

* **测试**
  * 添加源文件路径解析的完整测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->